### PR TITLE
Add dash to Regex filtering in get_id/0

### DIFF
--- a/lib/mix_deploy/user.ex
+++ b/lib/mix_deploy/user.ex
@@ -13,7 +13,7 @@ defmodule MixDeploy.User do
     [[user], [group], groups] = for pair <- String.split(String.trim(data), " ") do
       [_name, pairs] = String.split(pair, "=")
       for pair <- String.split(pairs, ",") do
-        [num, name] = Regex.run(~R/^(\d+)\(([a-zA-Z1-9_.]+)\)$/, pair, capture: :all_but_first)
+        [num, name] = Regex.run(~R/^(\d+)\(([a-zA-Z1-9_.-]+)\)$/, pair, capture: :all_but_first)
         {name, String.to_integer(num)}
       end
     end


### PR DESCRIPTION
Resolves #3 

The issue was caused by `1000(google-sudoers)`, the Regex is missing a dash, and error at pattern matching.