### PR TITLE
Fix creating directories and copying files

### DIFF
--- a/lib/mix/tasks/deploy.ex
+++ b/lib/mix/tasks/deploy.ex
@@ -524,7 +524,7 @@ defmodule Mix.Tasks.Deploy.Generate do
         %{dir | path: Mix.Tasks.Deploy.expand_vars(dir.path, cfg)}
       end
 
-    vars = cfg ++ [create_dirs: dirs, copy_files: files]
+    vars = [create_dirs: dirs, copy_files: files] ++ cfg
 
     for template <- cfg[:templates], do: write_template(vars, cfg[:bin_dir], template)
 


### PR DESCRIPTION
The `deploy-create-dirs` script generated by the task doesn't create any directories. As far as I can tell in the current implementation it never will except for directories specifically mentioned in the `:create_dirs` configuration option.

The problem is this line: https://github.com/cogini/mix_deploy/blob/b76b063b11ce32dbcd1c1ed06028e31bffc7c979/lib/mix/tasks/deploy.ex#L527

Since both `:create_dirs` and `:copy_files` default to `[]`, that will already be present in `cfg` and take precedence over the items concatenated to the list. Prepending them to the list fixes the issue, and doesn't ignore user defined values either, since those are taken into consideration earlier in the function.