### PR TITLE
fix : avoid duplicate keys in the bindings passed to EEx.eval_file

### DIFF
--- a/lib/mix/tasks/deploy.ex
+++ b/lib/mix/tasks/deploy.ex
@@ -524,7 +524,7 @@ defmodule Mix.Tasks.Deploy.Generate do
         %{dir | path: Mix.Tasks.Deploy.expand_vars(dir.path, cfg)}
       end
 
-    vars = [create_dirs: dirs, copy_files: files] ++ cfg
+    vars = Keyword.merge(cfg, [create_dirs: dirs, copy_files: files])
 
     for template <- cfg[:templates], do: write_template(vars, cfg[:bin_dir], template)
 


### PR DESCRIPTION
Template evaluation fails when there are multiple entries for the same key in 'vars'. A merge is needed.