### PR TITLE
Fix a syntax error in the config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ config :mix_systemd,
   ],
   # Set individual env vars
   env_vars: [
-    "PHX_SERVER=true"
-    "PORT=8080",
+    "PHX_SERVER=true",
+    "PORT=8080"
   ],
   # Create standard config dirs
   dirs: [

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ config :mix_systemd,
 ```elixir
 config :mix_deploy,
   app_user: "app",
-  app_group: "app"
+  app_group: "app",
   # Copy config/environment to /etc/foo/environment
   copy_files: [
     %{


### PR DESCRIPTION
There was a misplaced comma in the example config, now it can be copy/pasted without errors.