### PR TITLE
Fix incorrect GID retrieval on Linux

### DIFF
--- a/lib/mix_deploy/user.ex
+++ b/lib/mix_deploy/user.ex
@@ -57,7 +57,7 @@ defmodule MixDeploy.User do
   @spec get_gid(os_type(), binary) :: non_neg_integer
   defp get_gid({:unix, :linux}, name) do
     {:ok, info} = get_user_info(name)
-    info.uid
+    info.gid
   end
 
   defp get_gid({:unix, :darwin}, name) do


### PR DESCRIPTION
In `MixDeploy.User.get_gid/1`, the implementation for `:unix, :linux` was incorrectly returning `info.uid` instead of `info.gid`. This caused deployments to use the user's UID as their group ID on Linux systems.

This PR fixes the function to return `info.gid`.

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.